### PR TITLE
Fix incorrect parsing of ending episode numbers

### DIFF
--- a/MediaBrowser.Naming/TV/EpisodePathParser.cs
+++ b/MediaBrowser.Naming/TV/EpisodePathParser.cs
@@ -94,8 +94,29 @@ namespace MediaBrowser.Naming.TV
                     var endingNumberGroup = match.Groups["endingepnumber"];
                     if (endingNumberGroup != null)
                     {
-                        if (int.TryParse(endingNumberGroup.Value, NumberStyles.Any, CultureInfo.InvariantCulture, out num))
+                        bool bEndingNumberValid = true;
+                        int nextIndex = endingNumberGroup.Index + endingNumberGroup.Length;
+                        string nextChar = name.Substring(nextIndex, 1).ToLower();
+                        if (("0123456789".Contains(nextChar)))
                         {
+                            // The regex expressions look for a number with a length of 2 or 3 charachters
+                            // if the following character is another digit, the parsed ending number would be incorrect anyway
+                            // This will fix erroneous parsing of something like "series-s09e14-1080p.mkv"
+                            // as a multi-episode from E14 to E108
+                            bEndingNumberValid = false;
+                        }
+
+                        if (nextChar == "p" || nextChar == "i")
+                        {
+                            // This will fix erroneous parsing of something like "series-s09e14-720p.mkv"
+                            // as a multi-episode from E14 to E720
+                            // It should be safe to assume that a _real_ ending episode number will never be followed by those letters
+                            bEndingNumberValid = false;
+                        }
+
+                        if (bEndingNumberValid && int.TryParse(endingNumberGroup.Value, NumberStyles.Any, CultureInfo.InvariantCulture, out num))
+                        {
+                            
                             result.EndingEpsiodeNumber = num;
                         }
                     }


### PR DESCRIPTION
When files are named like "series-s09e14-1080p.mkv" the resolution
indicator was erroneously parsed as ending episode number
